### PR TITLE
Add Laravel Horizon, Scheduler and Quick Deploy integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ It is highly recommended that you store all inputs using [GitHub Secrets](https:
 | `worker_daemon`             | no       | `true`                                 | Worker "daemon" (if creation is requested).                                                                                                 |
 | `worker_force`              | no       | `false`                                | Worker "force" (if creation is requested).                                                                                                  |
 | `worker_queue`              | no       |                                        | Worker queue (if creation is requested). Default queue will be used if not defined.                                                         |
+| `horizon_enabled`           | no       | `false`                                | Enable Laravel Horizon integration.                                                                                                         |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ It is highly recommended that you store all inputs using [GitHub Secrets](https:
 | `worker_queue`              | no       |                                        | Worker queue (if creation is requested). Default queue will be used if not defined.                                                         |
 | `horizon_enabled`           | no       | `false`                                | Enable Laravel Horizon integration.                                                                                                         |
 | `scheduler_enabled`         | no       | `false`                                | Enable Laravel Scheduler integration.                                                                                                       |
+| `quick_deploy_enabled`      | no       | `false`                                | Enable quick deployment trigger.                                                                                                            |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ It is highly recommended that you store all inputs using [GitHub Secrets](https:
 | `worker_force`              | no       | `false`                                | Worker "force" (if creation is requested).                                                                                                  |
 | `worker_queue`              | no       |                                        | Worker queue (if creation is requested). Default queue will be used if not defined.                                                         |
 | `horizon_enabled`           | no       | `false`                                | Enable Laravel Horizon integration.                                                                                                         |
+| `scheduler_enabled`         | no       | `false`                                | Enable Laravel Scheduler integration.                                                                                                       |
 
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,10 @@ inputs:
     description: 'Enable Laravel Horizon integration'
     required: false
     default: 'false'
+  scheduler_enabled:
+    description: 'Enable Laravel Scheduler integration'
+    required: false
+    default: 'false'
 
 outputs:
   host:
@@ -208,3 +212,5 @@ runs:
         INPUT_WORKER_DAEMON: ${{ inputs.worker_daemon }}
         INPUT_WORKER_FORCE: ${{ inputs.worker_force }}
         INPUT_WORKER_QUEUE: ${{ inputs.worker_queue }}
+        INPUT_HORIZON_ENABLED: ${{ inputs.horizon_enabled }}
+        INPUT_SCHEDULER_ENABLED: ${{ inputs.scheduler_enabled }}

--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,10 @@ inputs:
   worker_queue:
     description: 'Worker queue (if creation is requested). Default queue will be used if not defined.'
     required: false
+  horizon_enabled:
+    description: 'Enable Laravel Horizon integration'
+    required: false
+    default: 'false'
 
 outputs:
   host:

--- a/action.yml
+++ b/action.yml
@@ -152,6 +152,10 @@ inputs:
     description: 'Enable Laravel Scheduler integration'
     required: false
     default: 'false'
+  quick_deploy_enabled:
+    description: 'Enable quick deployment trigger'
+    required: false
+    default: 'false'
 
 outputs:
   host:
@@ -214,3 +218,4 @@ runs:
         INPUT_WORKER_QUEUE: ${{ inputs.worker_queue }}
         INPUT_HORIZON_ENABLED: ${{ inputs.horizon_enabled }}
         INPUT_SCHEDULER_ENABLED: ${{ inputs.scheduler_enabled }}
+        INPUT_QUICK_DEPLOY_ENABLED: ${{ inputs.quick_deploy_enabled }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,6 +188,10 @@ if [[ -z "$INPUT_WORKER_FORCE" ]]; then
   INPUT_WORKER_FORCE='false'
 fi
 
+if [[ -z "$INPUT_HORIZON_ENABLED" ]]; then
+  INPUT_HORIZON_ENABLED='false'
+fi
+
 echo ""
 echo "* Check that stubs files exists"
 
@@ -854,6 +858,44 @@ else
   echo ""
   echo "$LAST_DEPLOYMENT_OUTPUT"
   exit 1
+fi
+
+if [[ $INPUT_HORIZON_ENABLED == 'true' ]]; then
+  echo ""
+  echo "* Enable Laravel Horizon integration"
+
+  API_URL="https://forge.laravel.com/api/v1/servers/$INPUT_FORGE_SERVER_ID/sites/$SITE_ID/integrations/horizon"
+
+  if [[ $DEBUG == 'true' ]]; then
+    echo "[DEBUG] CURL POST on $API_URL"
+    echo ""
+  fi
+
+  HTTP_STATUS=$(
+    curl -s -o response.json -w "%{http_code}" \
+      -X POST \
+      -H "$AUTH_HEADER" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      "$API_URL"
+  )
+
+  JSON_RESPONSE=$(cat response.json)
+
+  if [[ $DEBUG == 'true' ]]; then
+    echo "[DEBUG] response JSON:"
+    echo $JSON_RESPONSE
+    echo ""
+  fi
+
+  if [[ $HTTP_STATUS -eq 200 ]]; then
+    echo "Laravel Horizon integration enabled successfully"
+  else
+    echo "Failed to enable Laravel Horizon integration. HTTP status code: $HTTP_STATUS"
+    echo "JSON Response:"
+    echo "$JSON_RESPONSE"
+    exit 1
+  fi
 fi
 
 if [[ $INPUT_CREATE_WORKER == 'true' ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -192,6 +192,10 @@ if [[ -z "$INPUT_HORIZON_ENABLED" ]]; then
   INPUT_HORIZON_ENABLED='false'
 fi
 
+if [[ -z "$INPUT_SCHEDULER_ENABLED" ]]; then
+  INPUT_SCHEDULER_ENABLED='false'
+fi
+
 echo ""
 echo "* Check that stubs files exists"
 
@@ -892,6 +896,44 @@ if [[ $INPUT_HORIZON_ENABLED == 'true' ]]; then
     echo "Laravel Horizon integration enabled successfully"
   else
     echo "Failed to enable Laravel Horizon integration. HTTP status code: $HTTP_STATUS"
+    echo "JSON Response:"
+    echo "$JSON_RESPONSE"
+    exit 1
+  fi
+fi
+
+if [[ $INPUT_SCHEDULER_ENABLED == 'true' ]]; then
+  echo ""
+  echo "* Enable Laravel Scheduler integration"
+
+  API_URL="https://forge.laravel.com/api/v1/servers/$INPUT_FORGE_SERVER_ID/sites/$SITE_ID/integrations/laravel-scheduler"
+
+  if [[ $DEBUG == 'true' ]]; then
+    echo "[DEBUG] CURL POST on $API_URL"
+    echo ""
+  fi
+
+  HTTP_STATUS=$(
+    curl -s -o response.json -w "%{http_code}" \
+      -X POST \
+      -H "$AUTH_HEADER" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      "$API_URL"
+  )
+
+  JSON_RESPONSE=$(cat response.json)
+
+  if [[ $DEBUG == 'true' ]]; then
+    echo "[DEBUG] response JSON:"
+    echo $JSON_RESPONSE
+    echo ""
+  fi
+
+  if [[ $HTTP_STATUS -eq 200 ]]; then
+    echo "Laravel Scheduler integration enabled successfully"
+  else
+    echo "Failed to enable Laravel Scheduler integration. HTTP status code: $HTTP_STATUS"
     echo "JSON Response:"
     echo "$JSON_RESPONSE"
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -196,6 +196,10 @@ if [[ -z "$INPUT_SCHEDULER_ENABLED" ]]; then
   INPUT_SCHEDULER_ENABLED='false'
 fi
 
+if [[ -z "$INPUT_QUICK_DEPLOY_ENABLED" ]]; then
+  INPUT_QUICK_DEPLOY_ENABLED='false'
+fi
+
 echo ""
 echo "* Check that stubs files exists"
 
@@ -934,6 +938,44 @@ if [[ $INPUT_SCHEDULER_ENABLED == 'true' ]]; then
     echo "Laravel Scheduler integration enabled successfully"
   else
     echo "Failed to enable Laravel Scheduler integration. HTTP status code: $HTTP_STATUS"
+    echo "JSON Response:"
+    echo "$JSON_RESPONSE"
+    exit 1
+  fi
+fi
+
+if [[ $INPUT_QUICK_DEPLOY_ENABLED == 'true' ]]; then
+  echo ""
+  echo "* Trigger quick deployment"
+
+  API_URL="https://forge.laravel.com/api/v1/servers/$INPUT_FORGE_SERVER_ID/sites/$SITE_ID/deployment"
+
+  if [[ $DEBUG == 'true' ]]; then
+    echo "[DEBUG] CURL POST on $API_URL"
+    echo ""
+  fi
+
+  HTTP_STATUS=$(
+    curl -s -o response.json -w "%{http_code}" \
+      -X POST \
+      -H "$AUTH_HEADER" \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      "$API_URL"
+  )
+
+  JSON_RESPONSE=$(cat response.json)
+
+  if [[ $DEBUG == 'true' ]]; then
+    echo "[DEBUG] response JSON:"
+    echo $JSON_RESPONSE
+    echo ""
+  fi
+
+  if [[ $HTTP_STATUS -eq 200 ]]; then
+    echo "Quick deployment triggered successfully"
+  else
+    echo "Failed to trigger quick deployment. HTTP status code: $HTTP_STATUS"
     echo "JSON Response:"
     echo "$JSON_RESPONSE"
     exit 1


### PR DESCRIPTION
This PR adds support for enabling Laravel Horizon and Scheduler integrations, plus quick deployment triggers on Forge sites through three new input parameters:

- `horizon_enabled: true | false` - Enables Laravel Horizon integration
- `scheduler_enabled: true | false` - Enables Laravel Scheduler integration  
- `quick_deploy_enabled: true | false` - Triggers additional deployment

When enabled, these features make API calls to the appropriate Laravel Forge endpoints after successful deployment:

```yaml
- name: Deploy with Laravel integrations
  uses: web-id-fr/forge-review-app-action@v1.0.0
  with:
    forge_api_token: ${{ secrets.FORGE_API_TOKEN }}
    forge_server_id: ${{ secrets.FORGE_SERVER_ID }}
    create_database: 'true'
    database_password: ${{ secrets.FORGE_DB_PASSWORD }}
    horizon_enabled: 'true'
    scheduler_enabled: 'true'
    quick_deploy_enabled: 'true'
```

## Implementation Details

**API Endpoints Called:**
- Horizon: `POST /api/v1/servers/{serverId}/sites/{siteId}/integrations/horizon`
- Scheduler: `POST /api/v1/servers/{serverId}/sites/{siteId}/integrations/laravel-scheduler`
- Quick Deploy: `POST /api/v1/servers/{serverId}/sites/{siteId}/deployment`